### PR TITLE
Add support for markdown images

### DIFF
--- a/src/utils/pdf-gen-utils.js
+++ b/src/utils/pdf-gen-utils.js
@@ -350,27 +350,6 @@ function getParameterTableDef(parameters, paramType, tableLayout){
 
 }
 
-
-function getDataUri(url, callback) {
-    var image = new Image();
-
-    image.onload = function () {
-        var canvas = document.createElement('canvas');
-        canvas.width = this.naturalWidth; // or 'width' if you want a special/scaled size
-        canvas.height = this.naturalHeight; // or 'height' if you want a special/scaled size
-
-        canvas.getContext('2d').drawImage(this, 0, 0);
-
-        // Get raw image data
-        callback(canvas.toDataURL());
-
-        // ... or get as Data URI
-        // callback(canvas.toDataURL('image/png'));
-    };
-
-    image.src = url;
-}
-
 //Response Def
 function getResponseDef(responses, tableLayout){
   let respDef=[];
@@ -628,17 +607,21 @@ export function getInlineMarkDownDef(txt){
     text.split(imageRegex).forEach(function(val){
       let match = val.match(imageArgsGroup);
       if (match){
-        
-        final.push({text:':::img::: ' + match.groups.altText + ' src: ' + match.groups.src + ' width: ' + match.groups.width + ':::img:::', style:style});
         final.push(new Promise(function(resolve, reject){
           fetch(match.groups.src).then(function(response){
             response.blob().then(function(blob){
               var reader = new FileReader();
               reader.readAsDataURL(blob);
               reader.onloadend = function() {
-                resolve({
+                const result = {
                   image: reader.result
-                });
+                }
+                try {
+                  console.log(match.groups.width);
+                  result["width"] = match.groups.width;
+                } catch(e) {
+                }
+                resolve(result);
               }
             });
           });

--- a/src/utils/pdf-gen-utils.js
+++ b/src/utils/pdf-gen-utils.js
@@ -554,14 +554,15 @@ export function getInlineMarkDownDef(txt){
             response.blob().then(function(blob){
               var reader = new FileReader();
               reader.readAsDataURL(blob);
-              reader.onloadend = function() {
+              reader.onloadend = function(){
                 const result = {
                   image: reader.result
                 }
-                try {
-                  console.log(match.groups.width);
-                  result["width"] = match.groups.width;
-                } catch(e) {
+                if ('width' in match.groups && match.groups.width){
+                  result["width"] = parseInt(match.groups.width);
+                }
+                if ('height' in match.groups && match.groups.height){
+                  result["height"] = parseInt(match.groups.height);
                 }
                 resolve(result);
               }

--- a/src/utils/pdf-gen-utils.js
+++ b/src/utils/pdf-gen-utils.js
@@ -436,40 +436,6 @@ export function getApiListDef(spec, sectionHeading, tableLayout) {
   return content;
 }
 
-//Override buildin parser constructor
-marked.prototype.constructor.Parser.prototype.parse = function (src) {
-    this.inline = new marked.InlineLexer(src.links, this.options, this.renderer);
-    //custom rule/syntax
-    this.inline.rules.link = /^[!@]?\[((?:\[[^\]]*\]|[^\[\]]|\](?=[^\[]*\]))*)\]\(\s*<?([\s\S]*?)>?(?:\s+['"]([\s\S]*?)['"])?\s*\)/;
-    this.tokens = src.reverse();
-
-    var out = '';
-    while (this.next()) {
-        out += this.tok();
-    }
-
-    return out;
-};
-
-//Customize the outputLink Inline lexer
-marked.InlineLexer.prototype.outputLink = function(cap, link) {
-  var href = escape(link.href)
-    , title = link.title ? escape(link.title) : null;
-
-  console.log(title);
-
-  if (cap[0].charAt(0) === '@') {
-    return this.renderer.articles(
-        cap[1],
-        cap[2]
-    );
-  }
-
-  return cap[0].charAt(0) !== '!'
-    ? this.renderer.link(href, title, this.output(cap[1]))
-    : this.renderer.image(href, title, escape(cap[1]));
-};
-
 export function getMarkDownDef(tokens){
   let content = [];
   let uList={ ul:[], style:['topMarginRegular'] };
@@ -479,30 +445,10 @@ export function getMarkDownDef(tokens){
   tokens.forEach(function(v){
     if (v.type==='paragraph'){
       let textArr = getInlineMarkDownDef(v.text);
-      // check if content is image:
-      // var renderer = new marked.Renderer;
-      // renderer.image = function(href, title, alt) {
-      //   content.push({
-      //     text:"bunnybunny: " + href
-      //   });
-      //   return marked.Renderer.prototype.image.apply(this, arguments);
-      // }
-      // textArr.forEach(function(element) {
-      //   marked(element.text, {renderer: renderer});
-      //   // if (renderer.image){
-      //     content.push({
-      //       text:element.text + ' babab',
-      //       style:['topMarginRegular']
-      //     });
-      //   // }
-      // });
-      
       content.push({
         stack:textArr,
         style:['topMarginRegular']
       });
-
-      // console.log(textArr);
     }
     else if (v.type==='heading'){
       let headingStyle = [];
@@ -580,10 +526,6 @@ export function getMarkDownDef(tokens){
       oList={ ol:[], style:['topMarginRegular'] };
       listInsert='';
     }
-    else {
-      console.log(v);
-    }
-    
   });
   return content;
 
@@ -646,13 +588,11 @@ export function getInlineMarkDownDef(txt){
                 if (k%2 === 0){
                   if (c_val){
                     imageSplit(c_val, ['small']);
-                    // final.push({ text:c_val,style:['small']});
                   }
                 }
                 else{
                   if (c_val.trim){
                     imageSplit(c_val, ['small','mono','gray']);
-                    // final.push({ text:c_val,style:['small','mono', 'gray']});
                   }
                 }
               });
@@ -662,7 +602,6 @@ export function getInlineMarkDownDef(txt){
           else{
             if (b_val){
               imageSplit(b_val, ['small','bold']);
-              // final.push({text:b_val,style:['small','bold']});
             }
           }
         });
@@ -671,7 +610,6 @@ export function getInlineMarkDownDef(txt){
     else{
       if(bi_val){
         imageSplit(bi_val, ['small','bold','italics']);
-        // final.push({ text:bi_val, style:['small','bold', 'italics']});
       }
     }
   });

--- a/src/utils/pdf-gen.js
+++ b/src/utils/pdf-gen.js
@@ -138,17 +138,15 @@ export default async function createPdf(specUrl, options){
         return recursivePromise(val);
       }
       return val;
-    }))
-      .then(result => {
+    })).then(result => {
         if (Array.isArray(obj)) {
           return result;
         }
         return zipObj(Object.keys(obj), result);
       });
   });
-  // pdfMake.createPdf(finalDocDef).open();
+
   recursivePromise(finalDocDef).then(result => {
-    console.log(result);
     pdfMake.createPdf(result).open();
   });
 }

--- a/src/utils/pdf-gen.js
+++ b/src/utils/pdf-gen.js
@@ -123,5 +123,32 @@ export default async function createPdf(specUrl, options){
   };
   //pdfMake.vfs = pdfFonts.pdfMake.vfs;
   pdfMake.vfs = pdfFonts;
-  pdfMake.createPdf(finalDocDef).open();
+
+  const zipObj = (keys=[], vals=[]) => {
+    const result = {}
+    keys.forEach(function(key, idx) {
+      result[key] = vals[idx];
+    });
+    return result;
+  };
+
+  const recursivePromise = (function(obj) {
+    return Promise.all(Object.values(obj).map(val => {
+      if (typeof(val) === 'object' && !val.then) {
+        return recursivePromise(val);
+      }
+      return val;
+    }))
+      .then(result => {
+        if (Array.isArray(obj)) {
+          return result;
+        }
+        return zipObj(Object.keys(obj), result);
+      });
+  });
+  // pdfMake.createPdf(finalDocDef).open();
+  recursivePromise(finalDocDef).then(result => {
+    console.log(result);
+    pdfMake.createPdf(result).open();
+  });
 }


### PR DESCRIPTION
Allow users to add in images via Markdown's specification:

```
[example](https://my-domain.com/myimg.jpg)
```

This image is then inlined into the pdf as a base64 data URI.