### PR TITLE
Fix/status code spacing

### DIFF
--- a/src/utils/common-utils.js
+++ b/src/utils/common-utils.js
@@ -175,7 +175,8 @@ export function schemaToModel (schema, obj) {
   return obj;
 }
 
-export function schemaToPdf (schema, obj=[], name) {
+export function schemaToPdf (schema, name, colSpan = 3) {
+  let obj = [];
   if (schema==null){ return; }
   if (schema.type === "object" || schema.properties) {
     // Create a blank row for pdfMake to have the total count of columns
@@ -184,13 +185,13 @@ export function schemaToPdf (schema, obj=[], name) {
     ];
 
     for( let key in schema.properties ){
-      rows.push(schemaToPdf(schema.properties[key],[], key));
+      rows.push(schemaToPdf(schema.properties[key], key));
     }
 
     if (rows.length > 1){
       obj = [
         { 
-          colSpan: 3,
+          colSpan,
           stack:[
             (name ? {
               text:[ 
@@ -232,7 +233,7 @@ export function schemaToPdf (schema, obj=[], name) {
     if (schema.items.properties){
       typeOfArr = "object";
       for( let key in schema.items.properties ){
-        rows.push(schemaToPdf(schema.items.properties[key],[], key));
+        rows.push(schemaToPdf(schema.items.properties[key], key));
       }
     }
     else {
@@ -242,7 +243,7 @@ export function schemaToPdf (schema, obj=[], name) {
     if (rows.length > 1){
       obj = [
         { 
-          colSpan: 3,
+          colSpan,
           stack:[
             (name ? {
               text:[ 

--- a/src/utils/pdf-gen-utils.js
+++ b/src/utils/pdf-gen-utils.js
@@ -245,12 +245,10 @@ function getRequestBodyDef(requestBody, tableLayout, localize){
       let origSchema = requestBody.content[contentType].schema;
       if (origSchema){
         origSchema = JSON.parse(JSON.stringify(origSchema, removeCircularReferences()));
-        requestBodyTableDef = schemaToPdf(origSchema);
+        requestBodyTableDef = schemaToPdf(origSchema, null, null);
         if (requestBodyTableDef && requestBodyTableDef[0] && requestBodyTableDef[0].stack){
-          requestBodyTableDef[0].colSpan=undefined;
           requestBodyTableDef = {
             margin:[0,5,0,0],
-            //layout:tableLayout,
             layout:'noBorders',
             table: {
               widths:['*'],
@@ -351,30 +349,6 @@ function getResponseDef(responses, tableLayout, localize){
   let respDef=[];
   let allResponseModelTabelDefs=[];
   for(let statusCode in responses) {
-    for(let contentType in responses[statusCode].content ) {
-      let reponseModelTableDef;
-      let origSchema = responses[statusCode].content[contentType].schema;
-      if (origSchema){
-        origSchema = JSON.parse(JSON.stringify(origSchema, removeCircularReferences()));
-        reponseModelTableDef = schemaToPdf(origSchema);
-        if (reponseModelTableDef && reponseModelTableDef[0] && reponseModelTableDef[0].stack){
-          reponseModelTableDef[0].colSpan=undefined;
-          reponseModelTableDef = {
-            margin:[0,5,0,0],
-            //layout:tableLayout,
-            layout:'noBorders',
-            table: {
-              widths:['*'],
-              body: [
-                [{text:`${localize.responseModel} (${contentType})`,style:['small','b']}],
-                reponseModelTableDef
-              ]
-            }
-          };
-          allResponseModelTabelDefs.push(reponseModelTableDef);
-        }
-      }
-    }
 
     respDef.push({
       text:[
@@ -384,9 +358,28 @@ function getResponseDef(responses, tableLayout, localize){
       margin:[0,10,0,0]
     });
 
-    allResponseModelTabelDefs.map(function(respModelTableDef){
-      respDef.push(respModelTableDef);
-    })
+    for(let contentType in responses[statusCode].content ) {
+      let reponseModelTableDef;
+      let origSchema = responses[statusCode].content[contentType].schema;
+      if (origSchema){
+        origSchema = JSON.parse(JSON.stringify(origSchema, removeCircularReferences()));
+        reponseModelTableDef = schemaToPdf(origSchema, null, null);
+        if (reponseModelTableDef && reponseModelTableDef[0] && reponseModelTableDef[0].stack){
+          const responseModelDef = {
+            margin:[0,5,0,0],
+            layout:'noBorders',
+            table: {
+              widths:['*'],
+              body: [
+                [{text:`${localize.responseModel} (${contentType})`,style:['small','b']}],
+                reponseModelTableDef
+              ]
+            }
+          };
+          respDef.push(responseModelDef);
+        }
+      }
+    }
   }
   return respDef;
 }


### PR DESCRIPTION
Removes superfluous spacing between status codes without response model.
I didn't quite understand the purpose of the previous code. The responseModels seemed to be collected and readded to each status code.
![image](https://user-images.githubusercontent.com/7056064/64801134-28e6e580-d588-11e9-9821-2d577d33d2ec.png)
