### PR TITLE
Fix last page empty

### DIFF
--- a/src/pdf-gen.js
+++ b/src/pdf-gen.js
@@ -69,7 +69,7 @@ export default async function createPdf(specUrl, options) {
     allContent.push(securityDef);
   }
   if (options.includeApiDetails) {
-    apiDef = getApiDef(parsedSpec, '', options.pdfSchemaStyle, options.localize, options.includeExample);
+    apiDef = getApiDef(parsedSpec, '', options.pdfSchemaStyle, options.localize, options.includeExample, options.includeApiList);
     allContent.push(apiDef);
   }
   if (options.includeApiList) {

--- a/src/pdf-parts-gen.js
+++ b/src/pdf-parts-gen.js
@@ -312,7 +312,7 @@ function getResponseDef(responses, schemaStyle, localize) {
 }
 
 // API details def
-export function getApiDef(spec, filterPath, schemaStyle, localize, includeExample) {
+export function getApiDef(spec, filterPath, schemaStyle, localize, includeExample, includeApiList) {
   const content = [{ text: localize.api, style: ['h2', 'b'] }];
   let tagSeq = 0;
 
@@ -444,6 +444,12 @@ export function getApiDef(spec, filterPath, schemaStyle, localize, includeExampl
       );
     }
   });
+
+  // Remove last page break if api list not included
+  if (!includeApiList) {
+    content.pop();
+  }
+
   return content;
 }
 

--- a/src/pdf-parts-gen.js
+++ b/src/pdf-parts-gen.js
@@ -406,12 +406,14 @@ export function getApiDef(spec, filterPath, schemaStyle, localize, includeExampl
         });
       }
 
-      // End of Operation - Line
-      operationContent.push({
-        canvas: [{
-          type: 'line', x1: 0, y1: 5, x2: 595 - 2 * 35, y2: 5, lineWidth: 0.5, lineColor: '#cccccc',
-        }],
-      });
+      // End of Operation - Line (Except the last content)
+      if (j === tag.paths.length - 1) {
+        operationContent.push({
+          canvas: [{
+            type: 'line', x1: 0, y1: 5, x2: 595 - 2 * 35, y2: 5, lineWidth: 0.5, lineColor: '#cccccc',
+          }],
+        });
+      }
     }
 
     if (pathSeq > 0) {


### PR DESCRIPTION
This pull request is trying to fix two issues:

1. Prevent to add the line to last content of a section. (It might lead an unnecessary page break)
For example:
<img width="793" alt="Screenshot 2020-06-05 at 8 59 51 PM" src="https://user-images.githubusercontent.com/22940472/83889208-6e35ed80-a77d-11ea-94a3-5299bd43a935.png">

2. Last page of PDF is always blank a blank page if `includeApiList` is `false` (#39 )